### PR TITLE
[feat] #3 맵을 동적으로 읽도록 전처리 상수 구조체 및 malloc으로 대체

### DIFF
--- a/nuguri.c
+++ b/nuguri.c
@@ -1,18 +1,19 @@
+#define _XOPEN_SOURCE 600
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
+#include <unistd.h> // usleep
 #include <termios.h>
 #include <fcntl.h>
 #include <time.h>
 
-// 맵 및 게임 요소 정의 (수정된 부분)
-#define MAP_WIDTH 40  // 맵 너비를 40으로 변경
-#define MAP_HEIGHT 20
-#define MAX_STAGES 2
-#define MAX_ENEMIES 15 // 최대 적 개수 증가
-#define MAX_COINS 30   // 최대 코인 개수 증가
-#define MAX_HEALTH 3  // 최대 체력
+// 맵 및 게임 요소 정의 (동적 크기 지원)
+typedef struct
+{
+    int width;
+    int height;
+    char** rows;
+} Stage;
 
 // 구조체 정의
 typedef struct
@@ -28,10 +29,12 @@ typedef struct
 } Coin;
 
 // 전역 변수
-char map[MAX_STAGES][MAP_HEIGHT][MAP_WIDTH + 1];
+Stage* stages = NULL;   // map.txt에서 읽어 만든 스테이지 목록
+int stage_count = 0;    // 실제로 로드된 스테이지 개수
 int player_x, player_y;
 int stage = 0;
 int score = 0;
+const int MAX_HEALTH = 3;
 
 // 플레이어 상태
 int is_jumping = 0;
@@ -40,10 +43,12 @@ int on_ladder = 0;
 int health = 3;
 
 // 게임 객체
-Enemy enemies[MAX_ENEMIES];
+Enemy* enemies = NULL;  // 가변 길이 적 배열
 int enemy_count = 0;
-Coin coins[MAX_COINS];
+int enemy_capacity = 0; // 현재 할당된 적 배열 크기
+Coin* coins = NULL;     // 가변 길이 코인 배열
 int coin_count = 0;
+int coin_capacity = 0;  // 현재 할당된 코인 배열 크기
 
 // 터미널 설정
 struct termios orig_termios;
@@ -51,6 +56,8 @@ struct termios orig_termios;
 // 함수 선언
 void disable_raw_mode();
 void enable_raw_mode();
+// 임시로 모은 한 스테이지의 행들을 Stage 구조체로 묶어 stages 배열에 추가
+void append_stage(char** temp_lines, int temp_count, int max_width);
 void load_maps();
 void init_stage();
 void draw_game();
@@ -66,6 +73,7 @@ void draw_health();
 int main()
 {
     srand(time(NULL));
+    // 맵을 동적으로 읽어 stage_count와 stages를 세팅한 뒤 게임 루프 실행
     enable_raw_mode();
     load_maps();
     init_stage();
@@ -73,7 +81,7 @@ int main()
     char c = '\0';
     int game_over = 0;
 
-    while (!game_over && stage < MAX_STAGES)
+    while (!game_over && stage < stage_count)
     {
         if (kbhit())
         {
@@ -108,11 +116,11 @@ int main()
         draw_game();
         usleep(90000);
 
-        if (map[stage][player_y][player_x] == 'E')
+        if (stages[stage].rows[player_y][player_x] == 'E')
         {
             stage++;
             score += 100;
-            if (stage < MAX_STAGES)
+            if (stage < stage_count)
             {
                 init_stage();
             }
@@ -143,33 +151,130 @@ void enable_raw_mode()
     tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw);
 }
 
+// 임시로 모은 한 스테이지의 행들을 Stage 구조체로 묶어 stages 배열에 추가
+void append_stage(char** temp_lines, int temp_count, int max_width)
+{
+    if (temp_count == 0) return;
+
+    // 하나의 스테이지를 동적 할당: 높이는 읽은 행 수, 폭은 가장 긴 행 길이
+    Stage st;
+    st.width = max_width;
+    st.height = temp_count;
+    st.rows = (char**)malloc(sizeof(char*) * st.height);
+    if (!st.rows)
+    {
+        fprintf(stderr, "스테이지 메모리 할당 실패\n");
+        exit(1);
+    }
+
+    for (int i = 0; i < temp_count; i++)
+    {
+        st.rows[i] = (char*)malloc(st.width + 1);
+        if (!st.rows[i])
+        {
+            fprintf(stderr, "스테이지 행 메모리 할당 실패\n");
+            exit(1);
+        }
+        memset(st.rows[i], ' ', st.width);
+        int len = (int)strlen(temp_lines[i]);
+        if (len > st.width) len = st.width;
+        memcpy(st.rows[i], temp_lines[i], len);
+        st.rows[i][st.width] = '\0';
+        free(temp_lines[i]);
+    }
+    free(temp_lines);
+
+    Stage* new_stages = (Stage*)malloc(sizeof(Stage) * (stage_count + 1));
+    if (!new_stages)
+    {
+        fprintf(stderr, "스테이지 확장 실패\n");
+        exit(1);
+    }
+    if (stages && stage_count > 0) memcpy(new_stages, stages, sizeof(Stage) * stage_count);
+    free(stages);
+    stages = new_stages;
+    stages[stage_count++] = st;
+}
+
 // 맵 파일 로드
 void load_maps()
 {
+    // map.txt를 읽어 빈 줄로 스테이지를 구분하고, 각 스테이지를 동적 Stage로 변환
     FILE* file = fopen("map.txt", "r");
     if (!file)
     {
-        perror("map.txt 파일을 열 수 없습니다.");
+        fprintf(stderr, "map.txt 파일을 열 수 없습니다\n");
         exit(1);
     }
-    int s = 0, r = 0;
-    char line[MAP_WIDTH + 2]; // 버퍼 크기는 MAP_WIDTH에 따라 자동 조절됨
-    while (s < MAX_STAGES && fgets(line, sizeof(line), file))
+
+    char** temp_lines = NULL;
+    int temp_capacity = 0; // 읽은 행 버퍼 크기 (가변 확장)
+    int temp_count = 0;
+    int max_width = 0;     // 현재 스테이지의 최대 행 길이
+    char line[1024];
+
+    while (fgets(line, sizeof(line), file))
     {
-        if ((line[0] == '\n' || line[0] == '\r') && r > 0)
+        size_t len = strcspn(line, "\n\r");
+        line[len] = '\0';
+
+        if (len == 0)
         {
-            s++;
-            r = 0;
+            if (temp_count > 0)
+            {
+                append_stage(temp_lines, temp_count, max_width);
+                temp_lines = NULL;
+                temp_capacity = 0;
+                temp_count = 0;
+                max_width = 0;
+            }
             continue;
         }
-        if (r < MAP_HEIGHT)
+
+        if (temp_count >= temp_capacity)
         {
-            line[strcspn(line, "\n\r")] = 0;
-            strncpy(map[s][r], line, MAP_WIDTH + 1);
-            r++;
+            int new_capacity = temp_capacity ? temp_capacity * 2 : 32; // 점진적 2배 확장으로 realloc 대체
+            char** new_lines = (char**)malloc(sizeof(char*) * new_capacity);
+            if (!new_lines)
+            {
+                fprintf(stderr, "맵 라인 버퍼 확장 실패\n");
+                exit(1);
+            }
+            if (temp_lines && temp_capacity > 0) memcpy(new_lines, temp_lines, sizeof(char*) * temp_capacity);
+            free(temp_lines);
+            temp_lines = new_lines;
+            temp_capacity = new_capacity;
         }
+
+        temp_lines[temp_count] = (char*)malloc(len + 1);
+        if (!temp_lines[temp_count])
+        {
+            fprintf(stderr, "맵 라인 메모리 할당 실패\n");
+            exit(1);
+        }
+        memcpy(temp_lines[temp_count], line, len + 1);
+        if ((int)len > max_width) max_width = (int)len;
+        temp_count++;
     }
     fclose(file);
+
+    if (temp_count > 0)
+    {
+        append_stage(temp_lines, temp_count, max_width);
+        temp_lines = NULL;
+    }
+
+    if (temp_lines)
+    {
+        for (int i = 0; i < temp_count; i++) free(temp_lines[i]);
+        free(temp_lines);
+    }
+
+    if (stage_count == 0)
+    {
+        fprintf(stderr, "map.txt에 유효한 스테이지가 없습니다.\n");
+        exit(1);
+    }
 }
 
 
@@ -181,23 +286,57 @@ void init_stage()
     is_jumping = 0;
     velocity_y = 0;
 
-    for (int y = 0; y < MAP_HEIGHT; y++)
+    Stage* st = &stages[stage];
+
+    for (int y = 0; y < st->height; y++)
     {
-        for (int x = 0; x < MAP_WIDTH; x++)
+        for (int x = 0; x < st->width; x++)
         {
-            char cell = map[stage][y][x];
+            char cell = st->rows[y][x];
             if (cell == 'S')
             {
                 player_x = x;
                 player_y = y;
             }
-            else if (cell == 'X' && enemy_count < MAX_ENEMIES)
+            else if (cell == 'X')
             {
+                // 적 배열이 가득 차면 2배씩 확장 (0->8로 시작 후 2배씩 키워 재할당 횟수를 줄인다)
+                // realloc 대신 malloc+memcpy로 새 버퍼를 만들어 교체
+                if (enemy_count >= enemy_capacity)
+                {
+                    int new_cap = enemy_capacity ? enemy_capacity * 2 : 8;
+                    Enemy* new_enemies = (Enemy*)malloc(sizeof(Enemy) * new_cap);
+                    if (!new_enemies)
+                    {
+                        fprintf(stderr, "적 메모리 확장 실패\n");
+                        exit(1);
+                    }
+                    if (enemies && enemy_capacity > 0) memcpy(new_enemies, enemies, sizeof(Enemy) * enemy_capacity);
+                    free(enemies);
+                    enemies = new_enemies;
+                    enemy_capacity = new_cap;
+                }
                 enemies[enemy_count] = (Enemy){x, y, (rand() % 2) * 2 - 1};
                 enemy_count++;
             }
-            else if (cell == 'C' && coin_count < MAX_COINS)
+            else if (cell == 'C')
             {
+                // 코인 배열도 동일하게 가변 확장 (초기 8개, 이후 2배씩)
+                // realloc 없이 새 버퍼를 할당하고 이전 내용을 복사
+                if (coin_count >= coin_capacity)
+                {
+                    int new_cap = coin_capacity ? coin_capacity * 2 : 8;
+                    Coin* new_coins = (Coin*)malloc(sizeof(Coin) * new_cap);
+                    if (!new_coins)
+                    {
+                        fprintf(stderr, "코인 메모리 확장 실패\n");
+                        exit(1);
+                    }
+                    if (coins && coin_capacity > 0) memcpy(new_coins, coins, sizeof(Coin) * coin_capacity);
+                    free(coins);
+                    coins = new_coins;
+                    coin_capacity = new_cap;
+                }
                 coins[coin_count++] = (Coin){x, y, 0};
             }
         }
@@ -207,17 +346,31 @@ void init_stage()
 // 게임 화면 그리기
 void draw_game()
 {
+    Stage* st = &stages[stage];
     printf("\x1b[2J\x1b[H");
-    printf("Stage: %d | Score: %d\n", stage + 1, score);
+    printf("Stage: %d/%d | Score: %d\n", stage + 1, stage_count, score);
     printf("조작: ← → (이동), ↑ ↓ (사다리), Space (점프), q (종료)\n");
     draw_health(); //체력 표시 함수 호출
 
-    char display_map[MAP_HEIGHT][MAP_WIDTH + 1];
-    for (int y = 0; y < MAP_HEIGHT; y++)
+    // 동적 크기의 스테이지를 그리기 위해 매 프레임 임시 버퍼를 동적 할당해 사용 후 즉시 해제
+    char** display_map = (char**)malloc(sizeof(char*) * st->height);
+    if (!display_map)
     {
-        for (int x = 0; x < MAP_WIDTH; x++)
+        fprintf(stderr, "화면 버퍼 할당 실패\n");
+        exit(1);
+    }
+
+    for (int y = 0; y < st->height; y++)
+    {
+        display_map[y] = (char*)malloc(st->width + 1);
+        if (!display_map[y])
         {
-            char cell = map[stage][y][x];
+            fprintf(stderr, "화면 행 할당 실패\n");
+            exit(1);
+        }
+        for (int x = 0; x < st->width; x++)
+        {
+            char cell = st->rows[y][x];
             if (cell == 'S' || cell == 'X' || cell == 'C')
             {
                 display_map[y][x] = ' ';
@@ -227,6 +380,7 @@ void draw_game()
                 display_map[y][x] = cell;
             }
         }
+        display_map[y][st->width] = '\0';
     }
 
     for (int i = 0; i < coin_count; i++)
@@ -244,14 +398,16 @@ void draw_game()
 
     display_map[player_y][player_x] = 'P';
 
-    for (int y = 0; y < MAP_HEIGHT; y++)
+    for (int y = 0; y < st->height; y++)
     {
-        for (int x = 0; x < MAP_WIDTH; x++)
+        for (int x = 0; x < st->width; x++)
         {
             printf("%c", display_map[y][x]);
         }
         printf("\n");
+        free(display_map[y]);
     }
+    free(display_map);
 }
 
 // 게임 상태 업데이트
@@ -265,9 +421,10 @@ void update_game(char input)
 // 플레이어 이동 로직
 void move_player(char input)
 {
+    Stage* st = &stages[stage]; // 현재 스테이지의 동적 폭/높이/지면을 참조
     int next_x = player_x, next_y = player_y;
-    char floor_tile = (player_y + 1 < MAP_HEIGHT) ? map[stage][player_y + 1][player_x] : '#';
-    char current_tile = map[stage][player_y][player_x];
+    char floor_tile = (player_y + 1 < st->height) ? st->rows[player_y + 1][player_x] : '#'; // 맵 아래면 낙하 처리 (동적 높이)
+    char current_tile = st->rows[player_y][player_x];
 
     on_ladder = (current_tile == 'H');
 
@@ -279,7 +436,7 @@ void move_player(char input)
         break;
     case 'w': if (on_ladder) next_y--;
         break;
-    case 's': if (on_ladder && (player_y + 1 < MAP_HEIGHT) && map[stage][player_y + 1][player_x] != '#') next_y++;
+    case 's': if (on_ladder && (player_y + 1 < st->height) && st->rows[player_y + 1][player_x] != '#') next_y++;
         break;
     case ' ':
         if (!is_jumping && (floor_tile == '#' || on_ladder))
@@ -290,11 +447,13 @@ void move_player(char input)
         break;
     }
 
-    if (next_x >= 0 && next_x < MAP_WIDTH && map[stage][player_y][next_x] != '#') player_x = next_x;
+    // 동적 폭 기준으로 좌우 이동 가능 여부 확인
+    if (next_x >= 0 && next_x < st->width && st->rows[player_y][next_x] != '#') player_x = next_x;
 
     if (on_ladder && (input == 'w' || input == 's'))
     {
-        if (next_y >= 0 && next_y < MAP_HEIGHT && map[stage][next_y][player_x] != '#')
+        // 동적 높이 기준으로 사다리 이동 처리
+        if (next_y >= 0 && next_y < st->height && st->rows[next_y][player_x] != '#')
         {
             player_y = next_y;
             is_jumping = 0;
@@ -309,16 +468,17 @@ void move_player(char input)
             if (next_y < 0) next_y = 0;
             velocity_y++;
 
-            if (velocity_y < 0 && next_y < MAP_HEIGHT && map[stage][next_y][player_x] == '#')
+            // 위로 이동 시 천장을 만나면 속도 초기화
+            if (velocity_y < 0 && next_y < st->height && st->rows[next_y][player_x] == '#')
             {
                 velocity_y = 0;
             }
-            else if (next_y < MAP_HEIGHT)
+            else if (next_y < st->height)
             {
                 player_y = next_y;
             }
 
-            if ((player_y + 1 < MAP_HEIGHT) && map[stage][player_y + 1][player_x] == '#')
+            if ((player_y + 1 < st->height) && st->rows[player_y + 1][player_x] == '#')
             {
                 is_jumping = 0;
                 velocity_y = 0;
@@ -328,24 +488,30 @@ void move_player(char input)
         {
             if (floor_tile != '#' && floor_tile != 'H')
             {
-                if (player_y + 1 < MAP_HEIGHT) player_y++;
+                if (player_y + 1 < st->height) player_y++;
                 else init_stage();
             }
         }
     }
 
-    if (player_y >= MAP_HEIGHT) init_stage();
+    // 동적 높이 기준으로 맵 밖 추락 시 스테이지 리셋
+    if (player_y >= st->height) init_stage();
 }
 
 
 // 적 이동 로직
 void move_enemies()
 {
+    Stage* st = &stages[stage]; // 동적 폭/높이를 사용해 AI 경계 체크
     for (int i = 0; i < enemy_count; i++)
     {
         int next_x = enemies[i].x + enemies[i].dir;
-        if (next_x < 0 || next_x >= MAP_WIDTH || map[stage][enemies[i].y][next_x] == '#' || (enemies[i].y + 1 <
-            MAP_HEIGHT && map[stage][enemies[i].y + 1][next_x] == ' '))
+        int y = enemies[i].y;
+        int out_of_bounds = (next_x < 0 || next_x >= st->width);
+        int hit_wall = (!out_of_bounds && st->rows[y][next_x] == '#');
+        int gap_ahead = (y + 1 >= st->height) || (!out_of_bounds && st->rows[y + 1][next_x] == ' ');
+
+        if (out_of_bounds || hit_wall || gap_ahead)
         {
             enemies[i].dir *= -1;
         }


### PR DESCRIPTION
malloc + memcpy + free 방식을 통해 기존의 전처리 상수들로 이루어진 map 전역 변수를,
동적으로 map.txt 파일의 내용에 따라 크기가 결정되는 Stage 구조체로 변경했습니다.
map에 접근하는 다른 함수들도 변경된 Stage 구조체 멤버에 접근하도록 수정했습니다.