### PR TITLE
[fix] 동적 메모리 할당과 관련된 오류들 수정

### DIFF
--- a/nuguri.c
+++ b/nuguri.c
@@ -458,14 +458,11 @@ void draw_game()
     {
         for (int x = 0; x < st->width; x++)
         {
+            char object_cell = display_row[y][x];
             char base_cell = st->rows[y][x];
-            char cell = (base_cell == 'S' || base_cell == 'X' || base_cell == 'C') ? ' ' : base_cell;
-
-            if (cell == ' ')
-            {
-                cell = display_rows[y][x];
-            }
-
+            char map_cell = (base_cell == 'S' || base_cell == 'X' || base_cell == 'C') ? ' ' : base_cell;
+            char cell = (object_cell != ' ') ? object_cell : map_cell;
+            
             switch (cell)
             {
                 case '#':


### PR DESCRIPTION
#12 의 이슈를 다룸

###draw_game()에서 매 프레임 display_map 임시 버퍼를 할당해 프로그램이 느린 문제를 수정
- display_map 프레임 버퍼를 display_buffer/display_rows 전역 버퍼로 수정
- init_stage()에서 현재 스테이지 크기 기준으로 버퍼를 준비

###cls_mem() 함수에서 변수의 값까지 초기화하던 로직 제거
- 프로그램이 종료되는 분기이기 때문에 변수 값 초기화는 필요 없음