### PR TITLE
[fix] 선언 경고 방지 getch() 함수 선언 추가

### DIFF
--- a/nuguri.c
+++ b/nuguri.c
@@ -89,6 +89,7 @@ void void_screen();
 void cls_mem();
 void beep();
 void delay(int ms);
+int getch();
 
 int main()
 {


### PR DESCRIPTION
리눅스 환경에서 getch 함수가 선언되지 않아 컴파일 경고가 뜨는 문제 수정했습니다.