### PR TITLE
[fix] Remove unused getch() call to prevent unnecessary input handling

### DIFF
--- a/nuguri.c
+++ b/nuguri.c
@@ -148,7 +148,6 @@ int main()
                 continue;
             }
             #else
-            c = getch();
             if (c == 'q')
             {
                 game_over = 1;


### PR DESCRIPTION
getch() 호출 구문이 한번더 들어가있어서 unix환경에서 불필요한 입력대기 현상 발생